### PR TITLE
Add new feature flags test_accept_all/test_reject_all

### DIFF
--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -62,3 +62,5 @@ test_heap_size = ["td-benchmark", "td-payload/test_heap_size"]
 test_stack_size = ["td-benchmark"]
 test_disable_ra_and_accept_all = ["attestation/test"] # Dangerous: can only be used for test purpose to bypass the remote attestation
 sha2 = ["dep:sha2"]
+test_accept_all = [] # Test flag: Skip policy verification
+test_reject_all = [] # Test flag: Force migration status to always report unsupported

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -184,12 +184,25 @@ fn handle_pre_mig() {
         // The async task waiting for VMM response is always in the queue
         let new_request = PENDING_REQUEST.lock().take();
 
-        if let Some(request) = new_request {
-            async_runtime::add_task(async move {
-                let status = exchange_msk(&request)
-                    .await
-                    .map(|_| MigrationResult::Success)
-                    .unwrap_or_else(|e| e);
+            if let Some(request) = new_request {
+                async_runtime::add_task(async move {
+
+                    // Determine the status based on enabled features
+                    let status = {
+                        #[cfg(feature = "test_reject_all")]
+                        {
+                            // Don't execute exchange_msk, just return Unsupported
+                            MigrationResult::Unsupported
+                        }
+                        #[cfg(not(feature = "test_reject_all"))]
+                        {
+                            // Normal behavior - execute and use the actual result
+                            let exchange_result = exchange_msk(&request).await;
+                            exchange_result
+                                .map(|_| MigrationResult::Success)
+                                .unwrap_or_else(|e| e)
+                        }
+                    };
 
                 #[cfg(feature = "vmcall-raw")]
                 {


### PR DESCRIPTION
Add new feature flags test_accept_all/test_reject_all. If test_reject_all is set, MigTD always reports status as Unsupported.