### PR TITLE
Add support for igvm file format migtd-hash.

### DIFF
--- a/tools/migtd-hash/Cargo.toml
+++ b/tools/migtd-hash/Cargo.toml
@@ -12,3 +12,9 @@ crypto = { path = "../../src/crypto" }
 migtd = { path = "../../src/migtd", default-features = false }
 serde_json = "1.0"
 td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-features = false, features = ["tee"] }
+td-shim-interface = { path = "../../deps/td-shim/td-shim-interface" }
+igvm = "0.3.4"
+igvm_defs = "0.3.4"
+zerocopy = { version = "0.8.14", features = ["derive"] }
+thiserror = { version = "2", default-features = false }
+sha2 = "0.10"

--- a/tools/migtd-hash/src/main.rs
+++ b/tools/migtd-hash/src/main.rs
@@ -30,6 +30,9 @@ struct Config {
     /// Indicator to calculate final servtd_hash instead of servtd_info_hash (default false)
     #[clap(short, long)]
     pub calc_servtd_hash: bool,
+    /// The input MigTD image format
+    #[clap(short = 'f', long = "image-format", default_value = "tdvf")]
+    pub image_format: String,
 }
 
 fn main() {
@@ -49,6 +52,7 @@ fn main() {
     let servtd_info_hash = calculate_servtd_info_hash(
         &manifest,
         image,
+        &config.image_format,
         config.test_disable_ra_and_accept_all,
         servtd_attr,
     )

--- a/xtask/src/servtd_info_hash.rs
+++ b/xtask/src/servtd_info_hash.rs
@@ -28,6 +28,8 @@ pub(crate) struct ServtdInfoHashArgs {
     output: Option<PathBuf>,
     #[clap(short, long)]
     test_disable_ra_and_accept_all: bool,
+    #[clap(short = 'f', long = "image-format", default_value = "tdvf")]
+    pub image_format: String,
 }
 
 impl ServtdInfoHashArgs {
@@ -35,7 +37,8 @@ impl ServtdInfoHashArgs {
         let sh = Shell::new()?;
         let cmd = cmd!(sh, "cargo run -p migtd-hash  -- ")
             .args(&["--image", self.image()?.to_str().unwrap()])
-            .args(&["--manifest", self.servtd_info()?.to_str().unwrap()]);
+            .args(&["--manifest", self.servtd_info()?.to_str().unwrap()])
+            .args(&["--image-format", &self.image_format]);
 
         let cmd = if self.output.is_some() {
             cmd.args(&["--output-file", self.output()?.to_str().unwrap()])


### PR DESCRIPTION
These are temp changes while Intel is working on the PR. They are probably going make changes to td-shim. Creating a PR incase someone needs to use this before we merge with Intel changes. 

 cargo hash --image migtd.igvm --image-format igvm 

Running `/home/azureuser/MigTD_igvm/target/debug/migtd-hash --image migtd.igvm --manifest /home/azureuser/MigTD_igvm/config/servtd_info.json --image-format igvm`
mrtd 77fc75a394c829174b7088a094aa2817e49b23c9a2b89059efb54992b9405e8b6a2683e637b5aa654568e8dbdb28e729
84a5ee380130a628006399e45afeece1a70a81f7852f1de9cd0ed3769d906133461ed071bed07a86e60ec70880b1cd82

The original code only prints one hash for the entire binary. 

These changes print the mrtd hash followed by the hash of the entire image.